### PR TITLE
Fix for issue where data points are not highlighted

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -196,10 +196,7 @@ open class ChartDataSet: ChartBaseDataSet
     /// An empty array if no Entry object at that index.
     open override func entriesForXValue(_ xValue: Double) -> [ChartDataEntry]
     {
-        let match: (ChartDataEntry) -> Bool = { $0.x == xValue }
-        let i = partitioningIndex(where: match)
-        guard i < endIndex else { return [] }
-        return self[i...].prefix(while: match)
+        return self.filter { $0.x == xValue }
     }
     
     /// - Parameters:


### PR DESCRIPTION
The `entriesForXValue` func finds the data entries for a given x-axis
value. It used an optimization where it would do a binary search to find
the first matching entry then take a slice of data stopping when no more
entries matched.

The optimization broke the highlight feature because data points that
should have matched were not matching resulting in no entries being
returned.

This commit replaces the optimized code with a call to `.filter` which
will be slower for larger data sets but correctly returns filtered
entries.

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->